### PR TITLE
[FW-238] Fix bad usage of Shared Memory in DualPWM

### DIFF
--- a/src/vmcu/pin/__init__.py
+++ b/src/vmcu/pin/__init__.py
@@ -29,8 +29,6 @@ class PinType(Enum):
     EXTI = 10
     Ethernet= 11
 
-class DualPWM: ...
-
 class Pin:
     _pin_type_to_representation = {
         PinType.DigitalOut: DigitalOut,

--- a/src/vmcu/services/DualPWM.py
+++ b/src/vmcu/services/DualPWM.py
@@ -1,23 +1,24 @@
+from vmcu import pin
 from vmcu.shared_memory import SharedMemory
 from vmcu.pin.pinout import Pinout
-import vmcu.pin.memory as memory
 from ctypes import c_uint32
 from enum import Enum, auto, unique
+
+
 class DualPWM:
-    def __init__(self,pin1: Pinout, pin2: Pinout):
-            #register the pins 
-            self._pin1 = SharedMemory.get_pin(pin1,memory.DualPWM)
-            self._pin2 = SharedMemory.get_pin(pin2,memory.DualPWM)
-            
+    def __init__(self, pin1: Pinout, pin2: Pinout, shm: SharedMemory):
+        # register the pins
+        self._pin1 = shm.get_pin(pin1, pin.PinType.DualPWM)
+        self._pin2 = shm.get_pin(pin2, pin.PinType.DualPWM)
+
     def get_is_on(self) -> bool:
         return self._pin1.data.is_on
-    
+
     def get_duty_cycle(self) -> float:
         return self._pin1.data.duty_cycle
-    
+
     def get_frequency(self) -> int:
         return self._pin1.data.frequency
-    
+
     def get_dead_time_ns(self) -> int:
         return self._pin1.data.dead_time_ns
-  

--- a/src/vmcu/services/DualPWM.py
+++ b/src/vmcu/services/DualPWM.py
@@ -1,4 +1,4 @@
-from vmcu import pin
+from vmcu import pin.PinType
 from vmcu.shared_memory import SharedMemory
 from vmcu.pin.pinout import Pinout
 from ctypes import c_uint32
@@ -8,8 +8,8 @@ from enum import Enum, auto, unique
 class DualPWM:
     def __init__(self, pin1: Pinout, pin2: Pinout, shm: SharedMemory):
         # register the pins
-        self._pin1 = shm.get_pin(pin1, pin.PinType.DualPWM)
-        self._pin2 = shm.get_pin(pin2, pin.PinType.DualPWM)
+        self._pin1 = shm.get_pin(pin1, PinType.DualPWM)
+        self._pin2 = shm.get_pin(pin2, PinType.DualPWM)
 
     def get_is_on(self) -> bool:
         return self._pin1.data.is_on


### PR DESCRIPTION
When creating a new DualPWM, pins was been reached in a bad way, using the SharedMemory as a static method, and giving bad parameters